### PR TITLE
replaced nargchk with narginchk

### DIFF
--- a/parfor_progress.m
+++ b/parfor_progress.m
@@ -33,7 +33,7 @@ function percent = parfor_progress(N)
 
 % By Jeremy Scheff - jdscheff@gmail.com - http://www.jeremyscheff.com/
 
-error(nargchk(0, 1, nargin, 'struct'));
+narginchk(0, 1);
 
 if nargin < 1
     N = -1;


### PR DESCRIPTION
matlab suggests this replacement because nargchk will be removed in future releases
